### PR TITLE
Amend Github CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,9 +53,6 @@ jobs:
         if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium --with-deps
 
-      - name: Build
-        run: npm run build
-
       - name: Type check
         run: tsc
 


### PR DESCRIPTION
Remove build step from test workflow, as it does not actually use the compile JS